### PR TITLE
requirements.txt psycopq2 for pip changed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,5 +32,5 @@ sentry-sdk==0.13.2
 six==1.13.0
 sqlparse==0.3.0
 text-unidecode==1.3
-psycopg2==2.8
+psycopg2-binary==2.8.4
 urllib3==1.25.7 ; python_version >= '3.4'


### PR DESCRIPTION
My Environment
- Mac OS 10.15.3 (Cattalina)
- Python Virtual Environment(pipenv), python version 3.7 

### pip command related psycoqg2 yields the following error:

``` shell 
pip install -r requirements.txt
```

> ERROR: Failed building wheel for psycopg2



### Thus reflected the following change on the [requirements.txt](./requirements.txt):

``` shell
pip install psycopg2-binary
```

The module has the same functionality as psycopg2. [Stackoverflow link is attached for your further reference](https://stackoverflow.com/questions/5420789/how-to-install-psycopg2-with-pip-on-python)